### PR TITLE
Fix that the bundle output contains no meaningful code

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,7 @@ export default {
     {
       file: `./dist/${pkg.main}`,
       format: 'cjs',
+      exports: 'default',
       sourcemap: true,
     },
   ],

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,5 @@
 // make sure you import all components into this file
 
-export * from './InfiniteScroll'
+import InfiniteScroll from './InfiniteScroll'
+
+export default InfiniteScroll

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export * from './components'
+import InfiniteScroll from './components'
+
+export default InfiniteScroll


### PR DESCRIPTION
이슈 #1 과 별개로, Rollup 결과로 나온 `index.js` 및 `index.esm.js`에 컴포넌트 코드가 포함되지 않는 버그를 우회합니다.

It avoids the bug that Rollup didn't include any components in the build result.
